### PR TITLE
added tests

### DIFF
--- a/test/VisionModel/alexnet.jl
+++ b/test/VisionModel/alexnet.jl
@@ -1,7 +1,4 @@
-using Flux
-using Test
-
-@testset "Testing AlexNet Model" begin
+@testset "AlexNet" begin
   model = alexnet()
   @test size(model(rand(256, 256, 3, 50))) == (1000, 50)
 end

--- a/test/VisionModel/alexnet.jl
+++ b/test/VisionModel/alexnet.jl
@@ -1,0 +1,7 @@
+using Flux
+using Test
+
+@testset "Testing AlexNet Model" begin
+  model = alexnet()
+  @test size(model(rand(256, 256, 3, 50))) == (1000, 50)
+end

--- a/test/VisionModel/resnet.jl
+++ b/test/VisionModel/resnet.jl
@@ -1,7 +1,4 @@
-using Flux
-using Test
-
-@testset "Testing ResNet Models" begin
+@testset "ResNet" begin
   for MODEL in [
     ResNet18,
     ResNet34,

--- a/test/VisionModel/resnet.jl
+++ b/test/VisionModel/resnet.jl
@@ -6,7 +6,6 @@
     ResNet101,
     ResNet152,
     ]   
-    @info "Testing $(MODEL)..."
     model = MODEL()
     @test size(model(rand(256, 256, 3, 50))) == (1000, 50)
   end

--- a/test/VisionModel/resnet.jl
+++ b/test/VisionModel/resnet.jl
@@ -1,0 +1,16 @@
+using Flux
+using Test
+
+@testset "Testing ResNet Models" begin
+  for MODEL in [
+    ResNet18,
+    ResNet34,
+    ResNet50,
+    ResNet101,
+    ResNet152,
+    ]   
+    @info "Testing $(MODEL)..."
+    model = MODEL()
+    @test size(model(rand(256, 256, 3, 50))) == (1000, 50)
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
+using Flux
 using FluxModels
 using Test
 
-@testset "FluxModels.jl" begin
-    # Write your tests here.
+@info "Testing Flux Models..."
+@testset "Testing Vision Models" begin
+    include("VisionModel/alexnet.jl")
+    include("VisionModel/resnet.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,7 @@ using Flux
 using FluxModels
 using Test
 
-@info "Testing Flux Models..."
-@testset "Testing Vision Models" begin
+@testset "Vision Models" begin
     include("VisionModel/alexnet.jl")
     include("VisionModel/resnet.jl")
 end


### PR DESCRIPTION
Fixes #5 adding tests for the models
While testing on local system, I am getting ``LoadError`` due to the wrong syntax used in ``vgg.jl`` files. so shall I fix it already?
```
┌ Warning: `haskey(::TargetIterator, name::String)` is deprecated, use `Target(; name = name) !== nothing` instead.
│   caller = llvm_compat(::VersionNumber) at compatibility.jl:176
└ @ CUDAnative ~/.julia/packages/CUDAnative/e0IdN/src/compatibility.jl:176
┌ Warning: `haskey(::TargetIterator, name::String)` is deprecated, use `Target(; name = name) !== nothing` instead.
│   caller = llvm_compat(::VersionNumber) at compatibility.jl:176
└ @ CUDAnative ~/.julia/packages/CUDAnative/e0IdN/src/compatibility.jl:176
ERROR: LoadError: LoadError: LoadError: UndefVarError: convfilter not defined
Stacktrace:
 [1] include(::Module, ::String) at ./Base.jl:377
 [2] include(::String) at /home/nabanita07/FluxModels.jl/src/VisionModel/VisionModel.jl:1
 [3] top-level scope at /home/nabanita07/FluxModels.jl/src/VisionModel/VisionModel.jl:7
 [4] include(::Module, ::String) at ./Base.jl:377
 [5] include(::String) at /home/nabanita07/FluxModels.jl/src/FluxModels.jl:1
 [6] top-level scope at /home/nabanita07/FluxModels.jl/src/FluxModels.jl:4
 [7] include(::Module, ::String) at ./Base.jl:377
 [8] top-level scope at none:2
 [9] eval at ./boot.jl:331 [inlined]
 [10] eval(::Expr) at ./client.jl:449
 [11] top-level scope at ./none:3
in expression starting at /home/nabanita07/FluxModels.jl/src/VisionModel/vgg.jl:1
in expression starting at /home/nabanita07/FluxModels.jl/src/VisionModel/VisionModel.jl:7
in expression starting at /home/nabanita07/FluxModels.jl/src/FluxModels.jl:4
ERROR: LoadError: Failed to precompile FluxModels [5a58f058-f5b9-4204-9644-e62f3e70829d] to /home/nabanita07/.julia/compiled/v1.4/FluxModels/obERJ_HVOvf.ji.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] compilecache(::Base.PkgId, ::String) at ./loading.jl:1272
 [3] _require(::Base.PkgId) at ./loading.jl:1029
 [4] require(::Base.PkgId) at ./loading.jl:927
 [5] require(::Module, ::Symbol) at ./loading.jl:922
 [6] include(::String) at ./client.jl:439
 [7] top-level scope at none:6
in expression starting at /home/nabanita07/FluxModels.jl/test/runtests.jl:2
ERROR: Package FluxModels errored during testing
```